### PR TITLE
Feat/avoid-access-to-vendor-folder

### DIFF
--- a/vendor/.htaccess
+++ b/vendor/.htaccess
@@ -1,0 +1,7 @@
+# This directive redirect user to a 404 page
+# the page `/you/are/not/allowed/to/see/this/folder` does not really exist
+# but we do that to prevent user/attacker knowing that this
+# folder exists
+
+RewriteEngine On
+RewriteRule ^(.*)$ /you/are/not/allowed/to/see/this/folder [L]


### PR DESCRIPTION
Add directive to redirect attacker to a 404 page when intending to access the `vendor` folder. I defined url rewrite directive to redirect user to the`/you/are/not/allowed/to/see/this/folder` wich  does not really exist, then wordpress will present the 404 for him.